### PR TITLE
Added getAllSessionData() to the Conversation API.

### DIFF
--- a/src/main/java/org/bukkit/conversations/ConversationContext.java
+++ b/src/main/java/org/bukkit/conversations/ConversationContext.java
@@ -42,6 +42,14 @@ public class ConversationContext {
     }
 
     /**
+     * Gets the entire sessionData map.
+     * @return The full sessionData map.
+     */
+    public Map<Object, Object> getAllSessionData() {
+        return sessionData;
+    }
+
+    /**
      * Gets session data shared between all {@link Prompt} invocations. Use this as a way
      * to pass data through each Prompt as the conversation develops.
      * @param key The session data key.


### PR DESCRIPTION
Added `getAllSessionData()` method to the `ConversationContext.class` file. Allows for quick returning of the entire sessionData map.
