### PR TITLE
Update for BooleanPrompt within the Conversation API.

### DIFF
--- a/src/main/java/org/bukkit/conversations/BooleanPrompt.java
+++ b/src/main/java/org/bukkit/conversations/BooleanPrompt.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang.BooleanUtils;
 /**
  * BooleanPrompt is the base class for any prompt that requires a boolean response from the user.
  */
-public abstract class BooleanPrompt extends ValidatingPrompt{
+public abstract class BooleanPrompt extends ValidatingPrompt {
 
     public BooleanPrompt() {
         super();
@@ -14,12 +14,13 @@ public abstract class BooleanPrompt extends ValidatingPrompt{
 
     @Override
     protected boolean isInputValid(ConversationContext context, String input) {
-        String[] accepted = {"true", "false", "on", "off", "yes", "no"};
+        String[] accepted = {"true", "false", "on", "off", "yes", "no", "y", "n", "1", "0", "right", "wrong", "correct", "incorrect", "valid", "invalid"};
         return ArrayUtils.contains(accepted, input.toLowerCase());
     }
 
     @Override
     protected Prompt acceptValidatedInput(ConversationContext context, String input) {
+        if (input.equalsIgnoreCase("y") || input.equals("1") || input.equalsIgnoreCase("right") || input.equalsIgnoreCase("correct") || input.equalsIgnoreCase("valid")) input = "true";
         return acceptValidatedInput(context, BooleanUtils.toBoolean(input));
     }
 


### PR DESCRIPTION
Many people (to my knowledge) don't make use of the conversation API, but I've been implementing it heavily in a plugin I'm involved in and it has a lot of potential - it just needs to be expanded in some areas.

This particular commit expands the acceptable replies for the `BooleanPrompt` class.
