### PR TITLE
Fix tab completion

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/PluginsCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/PluginsCommand.java
@@ -1,11 +1,14 @@
 package org.bukkit.command.defaults;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
+
+import com.google.common.collect.ImmutableList;
 
 public class PluginsCommand extends BukkitCommand {
     public PluginsCommand(String name) {
@@ -39,5 +42,10 @@ public class PluginsCommand extends BukkitCommand {
         }
 
         return "(" + plugins.length + "): " + pluginList.toString();
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        return ImmutableList.of();
     }
 }

--- a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
@@ -1,11 +1,14 @@
 package org.bukkit.command.defaults;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+
+import com.google.common.collect.ImmutableList;
 
 public class ReloadCommand extends BukkitCommand {
     public ReloadCommand(String name) {
@@ -25,5 +28,10 @@ public class ReloadCommand extends BukkitCommand {
         Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Reload complete.");
 
         return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        return ImmutableList.of();
     }
 }

--- a/src/main/java/org/bukkit/command/defaults/TellCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/TellCommand.java
@@ -1,10 +1,14 @@
 package org.bukkit.command.defaults;
 
+import java.util.List;
+
+import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
+
+import com.google.common.collect.ImmutableList;
 
 public class TellCommand extends VanillaCommand {
     public TellCommand() {
@@ -47,5 +51,17 @@ public class TellCommand extends VanillaCommand {
     @Override
     public boolean matches(String input) {
         return input.equalsIgnoreCase("tell") || input.equalsIgnoreCase("w") || input.equalsIgnoreCase("msg");
+    }
+    
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        Validate.notNull(sender, "Sender cannot be null");
+        Validate.notNull(args, "Arguments cannot be null");
+        Validate.notNull(alias, "Alias cannot be null");
+
+        if (args.length >= 1) {
+            return super.tabComplete(sender, alias, args);
+        }
+        return ImmutableList.of();
     }
 }

--- a/src/main/java/org/bukkit/command/defaults/TestForCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/TestForCommand.java
@@ -1,8 +1,12 @@
 package org.bukkit.command.defaults;
 
-import org.bukkit.Bukkit;
+import java.util.List;
+
+import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+
+import com.google.common.collect.ImmutableList;
 
 public class TestForCommand extends VanillaCommand {
     public TestForCommand() {
@@ -22,5 +26,17 @@ public class TestForCommand extends VanillaCommand {
 
         sender.sendMessage(ChatColor.RED + "/testfor is only usable by commandblocks with analog output.");
         return true;
+    }
+    
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        Validate.notNull(sender, "Sender cannot be null");
+        Validate.notNull(args, "Arguments cannot be null");
+        Validate.notNull(alias, "Alias cannot be null");
+
+        if (args.length >= 1) {
+            return super.tabComplete(sender, alias, args);
+        }
+        return ImmutableList.of();
     }
 }


### PR DESCRIPTION
`/plugins` and `/reload` are returning the player list in tab completion when they should be returning nothing, and `/tell` and `/testfor` return the player list for parameters beyond the first.
