### PR TITLE
Fixed bug: Console input freezes on tab-complete when empty

### DIFF
--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -209,6 +209,10 @@ public class SimpleCommandMap implements CommandMap {
         Validate.notNull(sender, "Sender cannot be null");
         Validate.notNull(cmdLine, "Command line cannot null");
 
+        if(cmdLine.equals("")){
+            return new ArrayList<String>();
+        }
+
         int spaceIndex = cmdLine.indexOf(' ');
 
         if (spaceIndex == -1) {


### PR DESCRIPTION
Currently if you press tab when in console and have nothing written in your command line spigot/bukkit loops through EVERY command on the server and tries to find which one if them it is. This checks if the user has written something in the commandline or not. If not, do not perform tab-complete.
