### PR TITLE
[B+C] Add ItemMeta.hasCustomData/getCustomData. Adds BUKKIT-3221  

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -12,6 +12,7 @@ import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.material.MaterialData;
+import org.bukkit.plugin.Plugin;
 
 /**
  * Represents a stack of items
@@ -599,5 +600,37 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
         }
 
         return true;
+    }
+
+    /**
+     * This may provide a more efficient check to see if this ItemStack
+     * has a specific key in its metadata store,
+     * without actually unpacking the ItemMeta object.
+     * <p>
+     * Use this in place of getItemMeta().hasMetadata("field") for simple first-pass
+     * checks for data, if you don't necessarily need to unpack the data.
+     *
+     * @param key The String key to check for
+     * @return True if getItemMeta().hasMetadata(key)
+     */
+    public boolean hasMetadata(String key) {
+        return meta != null && meta.hasMetadata(key);
+    }
+
+    /**
+     * This may provide a more efficient check to see if this ItemStack
+     * has a specific key in its metadata store for a specific plugin,
+     * without actually unpacking the ItemMeta object.
+     * <p>
+     * Use this in place of getItemMeta().hasMetadata("field", plugin) for
+     * simple first-pass checks for data, if you don't necessarily need to
+     * unpack the data.
+     *
+     * @param key The String key to check for
+     * @param plugin The Plugin for which to check for data
+     * @return True if getItemMeta().hasMetadata(key)
+     */
+    public boolean hasMetadata(String key, Plugin plugin) {
+        return meta != null && meta.hasMetadata(key, plugin);
     }
 }

--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
@@ -3,16 +3,23 @@ package org.bukkit.inventory.meta;
 import java.util.List;
 import java.util.Map;
 
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.metadata.MetadataValue;
+import org.bukkit.metadata.Metadatable;
+import org.bukkit.plugin.Plugin;
 
 /**
  * This type represents the storage mechanism for auxiliary item data.
  * <p>
  * An implementation will handle the creation and application for ItemMeta.
  * This class should not be implemented by a plugin in a live environment.
+ * <p>
+ * The implementing class should implement Metadatable as a persistent data store attached
+ * to each ItemStack, and only accept PersistentMetadataValue entries.
  */
-public interface ItemMeta extends Cloneable, ConfigurationSerializable {
+public interface ItemMeta extends Cloneable, ConfigurationSerializable, Metadatable {
 
     /**
      * Checks for existence of a display name.
@@ -62,6 +69,42 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
      * @param lore the lore that will be set
      */
     void setLore(List<String> lore);
+
+    /**
+     * Check to see if the Metadatable store contains any data for any
+     * Plugin.
+     *
+     * @return true if there is any custom data present
+     */
+    public boolean hasMetadata();
+
+    /**
+     * Check to see if the Metadatable store contains a specific key
+     * for a specific Plugin.
+     *
+     * @param key the String key to check for
+     * @param plugin the Plugin for which to check for data
+     * @return true if the specified key is registered in this store
+     *   for the specified Plugin
+     */
+    public boolean hasMetadata(String key, Plugin plugin);
+
+    /**
+     * Return a single metadata value for a given key and Plugin.
+     *
+     * @param metadataKey the unique metadata key being sought
+     * @param owningPlugin the plugin that owns the data being sought
+     * @return the requested value, or null if not found
+     */
+    public MetadataValue getMetadata(String metadataKey, Plugin owningPlugin);
+
+    /**
+     * Set a MetadataVAlue for a given key.
+     *
+     * @param metadataKey A unique key to identify this metadata.
+     * @param newMetadataValue The metadata value to apply.
+     */
+    public void setMetadata(String metadataKey, MetadataValue newMetadataValue);
 
     /**
      * Checks for the existence of any enchantments.
@@ -123,6 +166,23 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
     * @return true if the enchantment conflicts, false otherwise
     */
     boolean hasConflictingEnchant(Enchantment ench);
+
+   /**
+    * See if this item is glowing for any reason.
+    * This could be due to enchantments, or to having its gow effect set with setGlowEffect(true)
+    *
+    * @return true if this item is glowing
+    */
+    boolean hasGlowEffect();
+
+    /**
+     * Force this item to glow, or remove an item's glow.
+     *
+     * Glow can only be removed this way if there are no enchantments on the item.
+     *
+     * @param glow if true, a visual glow effect will be added to the item, effect removed if false
+     */
+    void setGlowEffect(boolean glow);
 
     // Spigot start
     public class Spigot

--- a/src/main/java/org/bukkit/metadata/PersistentMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/PersistentMetadataValue.java
@@ -1,0 +1,175 @@
+package org.bukkit.metadata;
+
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A PersistentMetadataValue is a special case metadata item that may
+ * only contain ConfigurationSerializable Objects, Lists, Maps or
+ * basic Object types.
+ * <p>
+ * This class is primarily here to serve as a reminder that
+ * a persistent data store must hold serializable data.
+ */
+public class PersistentMetadataValue extends MetadataValueAdapter implements MetadataValue {
+    /**
+     * Store the internal value that is represented by this value.
+     * This is expected to be one of a set of a valid serializable types.
+     */
+    private final Object internalValue;
+
+    /**
+     * Initializes a PersistentMetadataValue with a
+     * ConfigurationSerializable Object
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final ConfigurationSerializable value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a String value.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final String value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with an Integer value.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final Integer value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a Boolean value.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final Boolean value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a Long value.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final Long value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a Double value.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final Double value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a Short value.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final Short value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a Byte value.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final Byte value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a Float value.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final Float value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a List value.
+     * <p>
+     * Note that the contents of the List must also be persistable,
+     * otherwise an IllegalArgumentException may be generated when
+     * the metadata store persists.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final List<?> value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with a Map value.
+     * <p>
+     * Note that the keys of the Map must be Strings, and the
+     * contents of the Map must be persistable,
+     * otherwise an IllegalArgumentException may be generated when
+     * the metadata store persists.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    public PersistentMetadataValue(Plugin owningPlugin, final Map<String, ?> value) {
+        this(owningPlugin, (Object)value);
+    }
+
+    /**
+     * Initializes a PersistentMetadataValue with an Object value.
+     * <p>
+     * The Object must be one of the valid persistable object types.
+     *
+     * @param owningPlugin the {@link org.bukkit.plugin.Plugin} that created this metadata value
+     * @param value the value assigned to this metadata value
+     */
+    private PersistentMetadataValue(Plugin owningPlugin, final Object value) {
+        super(owningPlugin);
+        this.internalValue = value;
+    }
+
+    @Override
+    public Object value() {
+        return internalValue;
+    }
+
+    @Override
+    public void invalidate() {
+
+    }
+
+    public List<Object> asList() {
+        return internalValue instanceof List ? (List<Object>)internalValue : Collections.emptyList();
+    }
+
+    public Map<String, Object> asMap() {
+        return internalValue instanceof Map ? (Map<String, Object>)internalValue : Collections.<String, Object>emptyMap();
+    }
+}


### PR DESCRIPTION
## Spigot PR

This is my first time trying to submit a Spigot PR. I wasn't sure if this would work, or if I need to update patches and submit a PR against Spigot- please let me know!

This PR is a copy of one that has been sitting around in Bukkit for a while (but which got a lot of positive attention):

https://github.com/Bukkit/Bukkit/pull/1064
## The Issue

There is currently no API method to track an ItemStack through its lifecycle for the purpose of creating a custom item.
## Justification for this PR

The ability to create custom items by tagging them with arbitrary data could add lot of depth to what Plugin developers are able to offer.

There are various methods employed to accomplish this (protocol hacking, direct NBT editing, name/lore data storage) but they all have downsides and don't interact well with each other or the API.

The item "glow" API requested by BUKKIT-4767 is also added here, it was a very clean and easy fit into the metadata framework provided by the bulk of this PR, and will hopefully make testing all of this in conjunction easier.

This PR provides also provides a mechanism to store unknown or custom NBT data on items, which may be important given the addition of custom item data in 1.8.
## PR Breakdown
### Bukkit

The ItemMeta interface now extends Metadatable. This is a different kind of persistent metadata store that can not store arbitrary Object instances. I wanted to make that clear and hopefully avoid confusion, so I made a new PersistentMetadataValue type that must be used when storing custom item data.

Basic types, Lists and Maps can be stored, as can ConfigurationSerializeable objects.

ItemStack also contains two "hasMetadata" methods which can be used to do efficient first-pass checks for custom data without the expense of unpacking the ItemMeta structure.
### CraftBukkit

Custom data will be stored in a "bukkit" NBT tag on the NMS ItemStack. This is an implementation detail that could change in the future, but at present is the easiest and safest method for storing relatively small amounts of structured data on an item.

The "bukkit" tag itself is reserved for internal Bukkit use. This PR also implements the item "glow" API requested by BUKKIT-4767, using a custom "bukkit.glow" flag to maintain state independently of enchantments.

Custom Plugin metadata is stored in "bukkit.plugins.<pluginname>.". No effort is made to preserve data attached to items that is registered to an unloaded plugin.
## Testing Results and Materials

A JUnit test is provided in the CB PR which attempts to exercise the API as much as possible. There is also a plugin that can be used for testing, available here:

https://github.com/NathanWolf/Test-ItemMetaData/tree/Metadatable
http://mine.elmakers.com/Test-ItemMetaData.jar

This plugin has several commands available for adding custom data, testing with enchants, glow effect, and checking for data. 
### Plugin Commands

_All of the following must be used in-game._

invpush: Push your entire inventory into a serialized stack. Useful for testing item serialization.
invpop: Pop your stored inventory off the stack. Will drop any items you have to the ground.

_All of the following must be used while holding an item_

itemcheck: Display information about an item, including any custom data
itemclone: Make a copy of an item
itemunenchant: Remove all enchantments from an item
itemfly: Tag an item with some special data that also makes you fly when you swing it
itemunfly: Remove the special testing/fly data.
itemglow: Make an item glow
itemunglow: Make an item not glow, unless it's enchanted

After you've used /itemfly, the item will have its custom data updated each time you swing it. Use /itemcheck to verify the data is getting updated properly.
## Relevant PR(s)

B-1053 : https://github.com/Bukkit/Bukkit/pull/1053 - @Ribesg 's glow API
CB-1376: https://github.com/Bukkit/CraftBukkit/pull/1376 - Associated CB PR
## JIRA Ticket

https://bukkit.atlassian.net/browse/BUKKIT-3221
Also resolves these tickets: 
https://bukkit.atlassian.net/browse/BUKKIT-4864
https://bukkit.atlassian.net/browse/BUKKIT-4767
