### PR TITLE
add setCanBePushed and isPushable to LivingEntity

### DIFF
--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -391,4 +391,21 @@ public interface LivingEntity extends Entity, Damageable, ProjectileSource {
      * @return whether the operation was successful
      */
     public boolean setLeashHolder(Entity holder);
+    
+    /**
+     * Sets whether or not this entity can be pushed by other entities.
+     * <p>
+     * This method does not effect players as they cannot be pushed
+     * 
+     * @param pushable pushable or not
+     */
+    public void setCanBePushed(boolean pushable);
+    
+    /**
+     * Returns whether or not the entity is pushable
+     * 
+     * @return whether the entity is pushable
+     */
+    public boolean isPushable();
+    
 }


### PR DESCRIPTION
Currently if we need to stop an entity from being pushed we can put a invisible armor stand on their head, however, this creates other problems that we must deal with. This change would allow developers to toggle whether or not a entity can be pushed by other entities. This would help keep entities stationary without using NMS. Changes will have to be made to the Craftbukkit part of spigot but the github repo for that has a DMCA so I don't know how to make a pull request for that sorry.
